### PR TITLE
use express `send` instead of `end` in responses

### DIFF
--- a/lib/calendar/index.js
+++ b/lib/calendar/index.js
@@ -18,7 +18,7 @@ const main = (req, res, next) => {
 			else
 				return calendar(params.data).then(
 					(data) => {
-						if(data) return res.end(template({input: params.data, output: data}, null))
+						if(data) return res.send(template({input: params.data, output: data}, null))
 						error('noResults')
 					},
 					(error) => error('1')

--- a/lib/day/index.js
+++ b/lib/day/index.js
@@ -13,8 +13,8 @@ const main = (req, res, next) => {
 			else
 				return day(params.data).then(
 					(data) => {
-						if(data) return res.end(template({input: params.data, output: data}, null))
-						return res.status(400).end(template(null, 'Leider wurden keine Angebote gefunden, die den Suchkriterien entsprechen.'))
+						if(data) return res.send(template({input: params.data, output: data}, null))
+						return res.status(400).send(template(null, 'Leider wurden keine Angebote gefunden, die den Suchkriterien entsprechen.'))
 					},
 					(error) => {console.error(error); return res.status(400).end(template(null, msg))}
 				)

--- a/lib/faq/index.js
+++ b/lib/faq/index.js
@@ -68,7 +68,7 @@ const generate = () => {
 }
 
 const main = (req, res, next) => {
-	res.end(generate())
+	res.send(generate())
 }
 
 module.exports = main

--- a/lib/impressum/index.js
+++ b/lib/impressum/index.js
@@ -54,7 +54,7 @@ const generate = () => {
 }
 
 const main = (req, res, next) => {
-	res.end(generate())
+	res.send(generate())
 }
 
 module.exports = main

--- a/lib/main/index.js
+++ b/lib/main/index.js
@@ -6,11 +6,11 @@ const template = require('./template')
 const main = (req, res, next) => {
 	params(req.query).then(
 		(data) => {
-			if(data.error) return res.status(400).end(template(data))
-			return res.end(template(data))
+			if(data.error) return res.status(400).send(template(data))
+			return res.send(template(data))
 		},
 		(error) => {
-			return res.end(template())
+			return res.send(template())
 		}
 	)
 	.catch(console.error)


### PR DESCRIPTION
this is to make sure that headers such as `Content-Type` are
automatically set as required (which is needed for Twitter to properly
create a card for the content).

The express documentation [actually says about `end`](http://expressjs.com/en/api.html#res.end): `If you need to respond with data, instead use methods such as res.send() and res.json().`