### PR TITLE
add opengraph for all pages

### DIFF
--- a/lib/calendar/template.js
+++ b/lib/calendar/template.js
@@ -6,12 +6,15 @@ const moment = require('moment-timezone')
 const mdf = require('moment-duration-format')
 const sort = require('lodash').sortBy
 const options = require('../api').options
+const opengraph = require('../helpers').openGraph
 
 const head = (data) => {
+	const title = generateSubTitleRoute(data).join('')+' | Kalender';
 	const elements = [
 		html.meta({charset: 'utf-8'}),
 		html.meta({name: 'viewport', content: "width=device-width, initial-scale=1.0"}),
-		html.title(null, generateSubTitleRoute(data).join('')+' | Kalender | Bahn-Preiskalender'),
+		html.title(null, ` ${title}| Bahn-Preiskalender`),
+		...opengraph(title),
 		html.link({rel: 'stylesheet', type: 'text/css', href: 'assets/reset.css'}),
 		html.link({rel: 'stylesheet', type: 'text/css', href: 'assets/base.css'}),
 		html.link({rel: 'stylesheet', type: 'text/css', href: 'assets/calendar.css'})

--- a/lib/day/template.js
+++ b/lib/day/template.js
@@ -11,14 +11,17 @@ const enc = require('urlencode')
 const timezone = require('config').timezone
 const options = require('../api').options
 const buildLink = require('../api').shopLink
+const opengraph = require('../helpers').openGraph
 
 const typeIndex = ['RB', 'RE', 'IRE', 'IC', 'IEC', 'EC', 'ICE']
 
 const head = (data) => {
+	const title = generateSubTitleRoute(data).join('')+' | Tagesansicht'
 	const elements = [
 		html.meta({charset: 'utf-8'}),
 		html.meta({name: 'viewport', content: "width=device-width, initial-scale=1.0"}),
-		html.title(null, generateSubTitleRoute(data).join('')+' | Tagesansicht | Bahn-Preiskalender'),
+		html.title(null, `${title} | Bahn-Preiskalender`),
+	    ...opengraph(title),
 		html.link({rel: 'stylesheet', type: 'text/css', href: 'assets/reset.css'}),
 		html.link({rel: 'stylesheet', type: 'text/css', href: 'assets/base.css'}),
 		html.link({rel: 'stylesheet', type: 'text/css', href: 'assets/day.css'})

--- a/lib/faq/index.js
+++ b/lib/faq/index.js
@@ -2,6 +2,7 @@
 
 const html = require('pithy')
 const beautify = require('js-beautify').html
+const opengraph = require('../helpers').openGraph;
 
 const questions = [
 	{
@@ -38,6 +39,7 @@ const head = () => {
 		html.meta({charset: 'utf-8'}),
 		html.meta({name: 'viewport', content: "width=device-width, initial-scale=1.0"}),
 		html.title(null, 'FAQ | Bahn-Preiskalender'),
+		...opengraph(),
 		html.link({rel: 'stylesheet', type: 'text/css', href: 'assets/reset.css'}),
 		html.link({rel: 'stylesheet', type: 'text/css', href: 'assets/base.css'}),
 		html.link({rel: 'stylesheet', type: 'text/css', href: 'assets/faq.css'})

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,8 +1,23 @@
 'use strict'
+const html = require('pithy')
 
 const formatPrice = (price) => {
 	price = price.toFixed(2).toString().split('.') 
 	return {euros: price[0], cents: price[1]}
 }
 
-module.exports = {formatPrice}
+const openGraph = (extraTitle) => {
+    let title = 'bahn.guru - der Bahn-Preiskalender';
+    if (extraTitle) {
+        title = `${title} - ${extraTitle}`
+    }
+
+    return [
+        html.meta({property: 'og:title', content: title}),
+        html.meta({property: 'og:description', content: 'Der Bahn-Guru hilft dir dabei, die günstigsten Sparpreise der Deutschen Bahn zu finden. 🚅'}),
+        html.meta({property: 'og:image', content: 'https://bahn.guru/assets/screenshot.png'}),
+        html.meta({name: 'twitter:card', content: 'summary'}),
+    ]
+}
+
+module.exports = {formatPrice, openGraph}

--- a/lib/impressum/index.js
+++ b/lib/impressum/index.js
@@ -2,13 +2,15 @@
 
 const html = require('pithy')
 const beautify = require('js-beautify').html
+const opengraph = require('../helpers').openGraph
 
 const head = () => {
 	const elements = [
 		html.meta({charset: 'utf-8'}),
 		html.meta({name: 'viewport', content: "width=device-width, initial-scale=1.0"}),
 		html.title(null, 'Rechtliches | Bahn-Preiskalender'),
-		html.link({rel: 'stylesheet', type: 'text/css', href: 'assets/reset.css'}),
+        ...opengraph(),
+        html.link({rel: 'stylesheet', type: 'text/css', href: 'assets/reset.css'}),
 		html.link({rel: 'stylesheet', type: 'text/css', href: 'assets/base.css'}),
 		html.link({rel: 'stylesheet', type: 'text/css', href: 'assets/impressum.css'})
 	]

--- a/lib/main/template.js
+++ b/lib/main/template.js
@@ -3,13 +3,7 @@
 const html = require('pithy')
 const beautify = require('js-beautify').html
 const options = require('../api').options
-
-const opengraph = [
-		html.meta({property: 'og:title', content: 'bahn.guru - der Bahn-Preiskalender'}),
-		html.meta({property: 'og:description', content: 'Der Bahn-Guru hilft dir dabei, die günstigsten Sparpreise der Deutschen Bahn zu finden. 🚅'}),
-		html.meta({property: 'og:image', content: 'https://bahn.guru/assets/screenshot.png'}),
-		html.meta({name: 'twitter:card', content: 'summary'}),
-]
+const opengraph = require('../helpers').openGraph
 
 
 const head = () => {
@@ -17,7 +11,7 @@ const head = () => {
 		html.meta({charset: 'utf-8'}),
 		html.meta({name: 'viewport', content: "width=device-width, initial-scale=1.0"}),
 		html.title(null, 'Bahn-Preiskalender'),
-		...opengraph,
+		...opengraph(),
 		html.link({rel: 'stylesheet', type: 'text/css', href: 'assets/reset.css'}),
 		html.link({rel: 'stylesheet', type: 'text/css', href: 'assets/base.css'}),
 		html.link({rel: 'stylesheet', type: 'text/css', href: 'assets/main.css'}),


### PR DESCRIPTION
In order to implement #8 this now adds the opengraph tags to all pages.
It keeps the same description text for all pages but uses an extra title if applicable. Of course one could go into much more detail when creating the titles and descriptions but I think this might be just good enough ;)