### PR TITLE
Fixes #22: Add support for Super Sparpreis Young

### DIFF
--- a/src/apis/bahn/lib/journeys.js
+++ b/src/apis/bahn/lib/journeys.js
@@ -7,7 +7,7 @@ const journeys = (params, day) => {
 	const dayTimestamp = +(moment.tz(day, settings.timezone).startOf('day'))
 	return client(params.origin.id, params.destination.id, moment(day).toDate(), {
 		class: params.class,
-		travellers: [{ typ: 'E', bc: params.bc }],
+		travellers: [{ typ: 'E', bc: params.bc, alter: params.alter }],
 	})
 		.then(results =>
 			results.filter(j => {

--- a/src/apis/bahn/lib/options.js
+++ b/src/apis/bahn/lib/options.js
@@ -24,6 +24,12 @@ export const input = (params) => ([
 			optionHTML(4, '50', (params.bc === 3 || params.bc === 4)),
 		]),
 		', ',
+		' Alter: ',
+		h('select', { name: 'alter', id: 'alter' }, [
+			optionHTML(27, 'ab 27 Jahre', params.alter === 27),
+			optionHTML(26, '15 – 26 Jahre', params.alter === 26),
+		]),
+		', ',
 	]),
 	h('span.optRow', [
 		h('label#departureAfter', ['ab: ', h('input', { type: 'text', placeholder: '--:--', value: (params.departureAfter) ? params.departureAfter.format('hh:mm') : '', name: 'departureAfter' }), ' Uhr']),
@@ -50,6 +56,7 @@ export const text = (params) => {
 	if (params.class && params.class === 1) result.push(params.class + '. Klasse', ', ')
 	if (params.bc && (params.bc === 1 || params.bc === 2)) result.push('mit BahnCard 25', ', ')
 	if (params.bc && (params.bc === 3 || params.bc === 4)) result.push('mit BahnCard 50', ', ')
+	if (params.alter && params.alter === 26) result.push('15 – 26 Jahre', ', ')
 	if (params.departureAfter && +params.departureAfter > 0) result.push('ab ' + params.departureAfter.format('HH:mm') + ' Uhr', ', ')
 	if (params.arrivalBefore && +params.arrivalBefore > 0) result.push('bis ' + params.arrivalBefore.format('HH:mm') + ' Uhr', ', ')
 	if (params.duration && params.duration > 0) result.push('Fahrzeit bis ' + params.duration + ' Stunden', ', ')
@@ -66,6 +73,7 @@ export const url = (params) => {
 	const result = []
 	if (params.class) result.push('class=' + params.class)
 	if (params.bc) result.push('bc=' + params.bcOriginal)
+	if (params.alter) result.push('alter=' + params.alter)
 	if (params.departureAfter) result.push('departureAfter=' + params.departureAfter.format('HH:mm'))
 	if (params.arrivalBefore) result.push('arrivalBefore=' + params.arrivalBefore.format('HH:mm'))
 	if (params.duration) result.push('duration=' + params.duration)

--- a/src/apis/bahn/lib/params.js
+++ b/src/apis/bahn/lib/params.js
@@ -24,6 +24,7 @@ const parseParams = (params) => {
 		class: 2,
 		bc: 0,
 		bcOriginal: 0,
+		alter: 27,
 		duration: null,
 		departureAfter: null,
 		arrivalBefore: null,
@@ -36,6 +37,8 @@ const parseParams = (params) => {
 		settings.bc = (settings.class === 2) ? +params.bc : (+params.bc === 0) ? 0 : (+params.bc - 1)
 		settings.bcOriginal = +params.bc
 	}
+	// age
+	if (+params.alter === 26) settings.alter = +params.alter
 	// duration
 	if (+params.duration && +params.duration > 0 && +params.duration < 24) settings.duration = +params.duration
 	// departureAfter & arrivalBefore


### PR DESCRIPTION
This PR adds support for the "Super Sparpreis Young", which is available to people between ages 15 and 26.

The implementation for that is unfortunately a bit hacky. While the clean implementation would use a traveler type param of `Y` (that's what the bahn.de website does), that doesn't seem to work with the API used here:

https://github.com/baltpeter/bahn.guru/blob/1d8fc992587c6740a5c01e5dd6c5afd3769b34ce/src/apis/bahn/lib/journeys.js#L10

According to https://github.com/juliuste/db-prices#usage, fetching prices for babies and children doesn't work either through that API. My guess would be that DB genuinely doesn't support that in the old API since they have since migrated from the "Sparpreis Finder" to the "Bestpreissuche" (https://www.bahn.de/service/buchung/bestpreissuche) which seems to use a different API.

However, it is possible to leave the traveler type as `E` and then specify an age (`alter`) in the discounted range. That's what I've done in this PR. I've opted to use `26` and `27` for the age parameter, as those are the two extremes.

I would have liked to also add support for children and babies but since I unfortunately don't think that's possible with juliuste/db-prices, you can only select '15 – 26' or '27 and above'.