### PR TITLE
Added link for link.bahn.guru in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,7 @@
 
 - [travel-price-map](https://github.com/juliuste/travel-price-map/) – Map of low-cost tickets ("Sparpreise") for several european cities
 - [db-prices](https://github.com/juliuste/db-prices/) – JavaScript client for the DB Sparpreise API
+- [link.bahn.guru](https://github.com/juliuste/link.bahn.guru) - Direct deep links to the [Deutsche Bahn shop](https://www.bahn.de).
 
 ## Contributing
 


### PR DESCRIPTION
That was missing, I thought it might be relevant to add since this is what the service uses in the backend.