### PR TITLE
Swap arrival and departure location

### DIFF
--- a/assets/styles/base.css
+++ b/assets/styles/base.css
@@ -50,6 +50,24 @@ body{
     text-decoration: underline;
 }
 
+#reverse-direction {
+	color: #000;
+	text-decoration: none;
+	border: 1px solid #044;
+	padding: .2rem;
+	margin: 0 .5rem;
+	border-radius: 4px;
+}
+
+#reverse-direction span {
+	transition: transform .2s ease-in-out;
+	display: inline-block;
+}
+
+#reverse-direction:hover span, #reverse-direction:focus span, #reverse-direction:active span {
+	transform: rotate(180deg);
+}
+
 #footer {
     position: absolute;
     font-size: 100%;

--- a/src/lib/routes/calendar/template.js
+++ b/src/lib/routes/calendar/template.js
@@ -5,7 +5,7 @@ import mdf from 'moment-duration-format'
 import * as helpers from '../helpers.js'
 
 const head = (api, data) => {
-	const title = generateSubTitleRoute(data).join('') + ' | Kalender'
+	const title = generateSubTitleRoute(api, data).join('') + ' | Kalender'
 	const elements = [
 		...helpers.staticHeader(api),
 		h('title', `${title} | ${api.settings.title}`),
@@ -15,10 +15,19 @@ const head = (api, data) => {
 	return h('head', elements)
 }
 
-const generateSubTitleRoute = (data) => {
+const generateSubTitleRoute = (api, data) => {
+	const reverseTravelLink = h('a', {
+		href: (
+			'?origin=' + data.input.destination.name +
+			'&destination=' + data.input.origin.name +
+			'&weeks=' + data.input.weeks +
+			'&' + (api.options.url(data.input).join('&'))
+		),
+		id: 'reverse-direction',
+	}, h('span', ' → '))
 	return [
 		data.input.origin.name,
-		' → ',
+		reverseTravelLink,
 		data.input.destination.name,
 	]
 }
@@ -121,7 +130,7 @@ const createTemplate = api => (data, error) => {
 		h('body', [
 			h('div#page', [
 				h('div#header', [h('a', { href: './start', title: 'Preiskalender' }, [h('h1', 'Preiskalender')])]),
-				h('div', { id: 'route', class: 'subtitle' }, [h('span', generateSubTitleRoute(data))]),
+				h('div', { id: 'route', class: 'subtitle' }, [h('span', generateSubTitleRoute(api, data))]),
 				h('div', { id: 'options', class: 'subtitle' }, generateSubTitleOptions(api, data)),
 				calendar(api, data),
 				h('div#more', moreLink(api, data)),

--- a/src/lib/routes/day/template.js
+++ b/src/lib/routes/day/template.js
@@ -10,7 +10,7 @@ import * as helpers from '../helpers.js'
 const productIndex = ['Bus', 'BUS', 'RB', 'RE', 'IRE', 'IC', 'IEC', 'EC', 'ICE']
 
 const head = (api, data) => {
-	const title = generateSubTitleRoute(data).join('') + ' | Tagesansicht'
+	const title = generateSubTitleRoute(api, data).join('') + ' | Tagesansicht'
 	const elements = [
 		...helpers.staticHeader(api),
 		h('title', `${title} | ${api.settings.title}`),
@@ -138,10 +138,19 @@ const generateSubTitleDate = (data) => {
 	]
 }
 
-const generateSubTitleRoute = (data) => {
+const generateSubTitleRoute = (api, data) => {
+	const reverseTravelLink = h('a', {
+		href: (
+			'?origin=' + data.input.destination.name +
+			'&destination=' + data.input.origin.name +
+			'&date=' + data.input.date.format('DD.MM.YYYY') +
+			'&' + (api.options.url(data.input).join('&'))
+		),
+		id: 'reverse-direction',
+	}, h('span', ' → '))
 	return [
 		data.input.origin.name,
-		' → ',
+		reverseTravelLink,
 		data.input.destination.name,
 	]
 }
@@ -161,7 +170,7 @@ const createTemplate = api => data => {
 		h('body', [
 			h('div#page', [
 				h('div#header', [h('a', { href: './start', title: 'Preiskalender' }, [h('h1', 'Preiskalender')])]),
-				h('div', { class: 'subtitle' }, [h('span', generateSubTitleRoute(data))]),
+				h('div', { class: 'subtitle' }, [h('span', generateSubTitleRoute(api, data))]),
 				h('div', { id: 'date', class: 'subtitle' }, generateSubTitleDate(data)),
 				h('div', { id: 'options', class: 'subtitle' }, generateSubTitleOptions(api, data)),
 				journeyTable(api, data),


### PR DESCRIPTION
Fix #17: Add a button in calendar and day view which allows to easily switch departure and arrival location. It allows to compare prices for the trip back home without needing to renter both city names again.


https://github.com/juliuste/bahn.guru/assets/967243/a28a638e-ed51-4e30-a418-d93f0ccdef88

